### PR TITLE
[feature] WhatsAppMessageTemplate: (#88) add sync twilio template

### DIFF
--- a/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.js
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.js
@@ -1,8 +1,23 @@
-// Copyright (c) 2021, Frappe and contributors
-// For license information, please see license.txt
-
 frappe.ui.form.on('WhatsApp Message Template', {
-	// refresh: function(frm) {
+	refresh: function (frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button(__('Sync Template'), () => {
+				frappe.call({
+					method: 'twilio_integration.twilio_integration.doctype.whatsapp_message_template.whatsapp_message_template.sync_twilio_template',
+					args: {
+						template_sid: frm.doc.template_sid,
+						template_name: frm.doc.name,
+					},
+					callback: function (r) {
+						if (r.message) {
+							frappe.msgprint(r.message);
+							frm.reload_doc();
+						}
+					}
+				});
+			});
 
-	// }
+			frm.page.set_inner_btn_icon(__('Sync Template'), 'refresh');
+		}
+	}
 });

--- a/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.js
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.js
@@ -1,23 +1,23 @@
 frappe.ui.form.on('WhatsApp Message Template', {
 	refresh: function (frm) {
-		if (!frm.is_new()) {
-			frm.add_custom_button(__('Sync Template'), () => {
+		frm.add_custom_button(__('Fetch Template Body'), () => {
+			if (frm.doc.template_sid) {
 				frappe.call({
 					method: 'twilio_integration.twilio_integration.doctype.whatsapp_message_template.whatsapp_message_template.sync_twilio_template',
 					args: {
 						template_sid: frm.doc.template_sid,
-						template_name: frm.doc.name,
 					},
+					freeze: 1,
+					freeze_message: __("Fetching from Twilio"),
 					callback: function (r) {
 						if (r.message) {
-							frm.set_value('template_body', r.message.body);
-							frappe.msgprint(r.message.message);
+							frm.set_value('template_body', r.message);
 						}
 					}
 				});
-			});
-
-			frm.page.set_inner_btn_icon(__('Sync Template'), 'refresh');
-		}
+			} else {
+				frappe.msgprint(__("Please set Template SID first"));
+			}
+		});
 	}
 });

--- a/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.js
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.js
@@ -10,8 +10,8 @@ frappe.ui.form.on('WhatsApp Message Template', {
 					},
 					callback: function (r) {
 						if (r.message) {
-							frappe.msgprint(r.message);
-							frm.reload_doc();
+							frm.set_value('template_body', r.message.body);
+							frappe.msgprint(r.message.message);
 						}
 					}
 				});

--- a/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.py
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_message_template/whatsapp_message_template.py
@@ -43,7 +43,6 @@ def sync_twilio_template(template_sid, template_name):
 	if not content:
 		frappe.throw(_("Unable to fetch template from Twilio"))
 
-	doc = frappe.get_cached_doc("WhatsApp Message Template", template_name)
-	doc.db_set("template_body", content.types.get("twilio/text", {}).get("body", ""))
+	body = content.types.get("twilio/text", {}).get("body", "")
 
-	return _("Template synced successfully from Twilio")
+	return {"body": body, "message": _("Template fetched successfully from Twilio")}

--- a/twilio_integration/twilio_integration/twilio_handler.py
+++ b/twilio_integration/twilio_integration/twilio_handler.py
@@ -110,11 +110,18 @@ class Twilio:
 		twilio_settings = frappe.get_doc("Twilio Settings")
 		if not twilio_settings.enabled:
 			frappe.throw(_("Please enable twilio settings before sending WhatsApp messages"))
-		
+
 		auth_token = get_decrypted_password("Twilio Settings", "Twilio Settings", 'auth_token')
 		client = TwilioClient(twilio_settings.account_sid, auth_token)
 
 		return client
+
+	@classmethod
+	def get_whatsapp_template(self, template_sid=None):
+		client = self.get_twilio_client()
+		template = client.content.v1.contents(template_sid).fetch()
+
+		return template
 
 class IncomingCall:
 	def __init__(self, from_number, to_number, meta=None):

--- a/twilio_integration/twilio_integration/twilio_handler.py
+++ b/twilio_integration/twilio_integration/twilio_handler.py
@@ -123,6 +123,7 @@ class Twilio:
 
 		return template
 
+
 class IncomingCall:
 	def __init__(self, from_number, to_number, meta=None):
 		self.from_number = from_number


### PR DESCRIPTION
# 🔄 Sync WhatsApp Message Template from Twilio

## ✅ Summary  
This PR adds the ability to **fetch and sync WhatsApp message templates from Twilio's Content API** directly into the `WhatsApp Message Template` doctype in Frappe.

---

https://github.com/user-attachments/assets/d2b657b8-2cd4-496e-a799-53930bc7e8ec

## 🧩 Features Introduced
- Adds a **"Sync Template"** button on existing `WhatsApp Message Template` document.
- On click, it fetches the template body from Twilio using the provided `template_sid`.
- Automatically updates the `template_body` field with the latest version from Twilio.
- Includes error handling and user feedback via `frappe.msgprint()`.

---

## 🔧 Backend Implementation
- Implements `sync_twilio_template(template_sid, template_name)` to:
  - Fetch template content via Twilio Content API.
  - Extract `twilio/text.body` from the response.
  - Update the corresponding Frappe doc with the new content.

- Uses `Twilio` class abstraction to handle connection and API interaction.

---

## 🧪 Testing
- Verified syncing of approved and published templates from Twilio.
- Validated UI behavior of the sync button for non-new records.
- Confirmed fallback/error message when:
  - Template is missing.
  - `template_sid` is invalid.
  - Twilio API call fails.

---

## 📝 Notes
- Ensure **Twilio Settings** is configured with:
  - Valid `account_sid`
  - Valid `auth_token`
- Only works with **approved** WhatsApp templates in Twilio.
- Button appears only when the document is not new (`!frm.is_new()`).

---
Closes [](https://github.com/ParaLogicTech/frappe/issues/88)

