### PR TITLE
Twilio Whatsapp communication delivery status update

### DIFF
--- a/twilio_integration/hooks.py
+++ b/twilio_integration/hooks.py
@@ -13,7 +13,8 @@ app_license = "MIT"
 boot_session = "twilio_integration.boot.boot_session"
 
 override_doctype_class = {
-	"Notification": "twilio_integration.overrides.notification_hooks.NotificationTwilio"
+	"Notification": "twilio_integration.overrides.notification_hooks.NotificationTwilio",
+	"Communication": "twilio_integration.overrides.communication_hooks.CommunicationTwilio",
 }
 
 doctype_js = {

--- a/twilio_integration/overrides/communication_hooks.py
+++ b/twilio_integration/overrides/communication_hooks.py
@@ -18,7 +18,7 @@ class CommunicationTwilio(Communication):
 		if self.sent_or_received == "Received":
 			return
 
-		if status_counts.get("Queued"):
+		if status_counts.get("Queued") or status_counts.get("Not Sent") or status_counts.get("Sending"):
 			delivery_status = "Sending"
 		elif status_counts.get("Undelivered") or status_counts.get("Error"):
 			delivery_status = "Error"

--- a/twilio_integration/overrides/communication_hooks.py
+++ b/twilio_integration/overrides/communication_hooks.py
@@ -1,0 +1,40 @@
+import frappe
+from collections import Counter
+from frappe.core.doctype.communication.communication import Communication
+
+
+class CommunicationTwilio(Communication):
+	def validate(self):
+		super().validate()
+
+	def set_delivery_status(self, commit=False):
+		"""Look into the status of WhatsApp Queue linked to this Communication and set the Delivery Status of this Communication"""
+		delivery_status = None
+
+
+		if self.communication_medium != "WhatsApp":
+			super().set_delivery_status()
+			return
+		else:
+			status_counts = Counter(
+				frappe.db.sql_list('''select status from `tabWhatsApp Message` where communication=%s''', self.name))
+
+			if status_counts.get("sending"):
+				delivery_status = "Sending"
+
+			elif status_counts.get("failed") or status_counts.get("undelivered"):
+				delivery_status = "Error"
+
+			elif status_counts.get("canceled"):
+				delivery_status = "Cancelled"
+
+			elif status_counts.get("sent") or status_counts.get("delivered") or status_counts.get("read"):
+				delivery_status = "Sent"
+
+			if delivery_status:
+				self.db_set("delivery_status", delivery_status)
+				self.notify_change("update")
+				self.notify_update()
+
+				if commit:
+					frappe.db.commit()

--- a/twilio_integration/overrides/communication_hooks.py
+++ b/twilio_integration/overrides/communication_hooks.py
@@ -4,9 +4,6 @@ from frappe.core.doctype.communication.communication import Communication
 
 
 class CommunicationTwilio(Communication):
-	def validate(self):
-		super().validate()
-
 	def set_delivery_status(self, commit=False):
 		"""Look into the status of WhatsApp Queue linked to this Communication and set the Delivery Status of this Communication"""
 		delivery_status = None
@@ -18,11 +15,14 @@ class CommunicationTwilio(Communication):
 		status_counts = Counter(
 			frappe.db.sql_list('''select status from `tabWhatsApp Message` where communication=%s''', self.name))
 
+		if self.sent_or_received == "Received":
+			return
+
 		if status_counts.get("Queued"):
 			delivery_status = "Sending"
 		elif status_counts.get("Undelivered") or status_counts.get("Error"):
 			delivery_status = "Error"
-		elif status_counts.get("Sent") or status_counts.get("Received") or status_counts.get("Delivered") or status_counts.get("Read"):
+		elif status_counts.get("Sent") or status_counts.get("Delivered") or status_counts.get("Read"):
 			delivery_status = "Sent"
 
 		if delivery_status:

--- a/twilio_integration/overrides/notification_hooks.py
+++ b/twilio_integration/overrides/notification_hooks.py
@@ -105,7 +105,7 @@ class NotificationTwilio(Notification):
 		communication = frappe.get_doc({
 			"doctype": "Communication",
 			"communication_type": "Automated Message",
-			"communication_medium": "Other",
+			"communication_medium": "WhatsApp",
 			"subject": f"WhatsApp",
 			"content": message,
 			"sent_or_received": "Sent",

--- a/twilio_integration/twilio_integration/api.py
+++ b/twilio_integration/twilio_integration/api.py
@@ -139,5 +139,5 @@ def whatsapp_message_status_callback(**kwargs):
 		message.db_set('status', args.MessageStatus.title())
 
 		if message.communication:
-			comm = frappe.get_cached_doc("Communication", message.communication)
+			comm = frappe.get_doc("Communication", message.communication)
 			comm.set_delivery_status()

--- a/twilio_integration/twilio_integration/api.py
+++ b/twilio_integration/twilio_integration/api.py
@@ -137,3 +137,7 @@ def whatsapp_message_status_callback(**kwargs):
 	if frappe.db.exists({'doctype': 'WhatsApp Message', 'id': args.MessageSid, 'from_': args.From, 'to': args.To}):
 		message = frappe.get_doc('WhatsApp Message', {'id': args.MessageSid, 'from_': args.From, 'to': args.To})
 		message.db_set('status', args.MessageStatus.title())
+
+		if message.communication:
+			comm = frappe.get_cached_doc("Communication", message.communication)
+			comm.set_delivery_status()


### PR DESCRIPTION
## Feature: Communication Delivery Status for WhatsApp

### Summary

This PR enhances the `Communication` DocType to track and display **delivery status** based on the status of linked **WhatsApp Message** documents. It ensures real-time updates when Twilio reports message status changes.

---

### Key Changes

#### 1. Communication DocType Enhancements
- Overridden `set_delivery_status` method to evaluate and set delivery status **only if the medium is WhatsApp**.
- Evaluates all linked `WhatsApp Message` records via the `communication` link field.

#### 2. Twilio Webhook Integration
- The `whatsapp_message_status_callback` function is updated to:
  - Update the status of the matching `WhatsApp Message`.
  - If the message is linked to a `Communication`, call `set_delivery_status()` to sync the delivery status.

---

### Delivery Status Mapping Logic

| WhatsApp Message Status                        | Communication.delivery_status |
| --------------------------------------------- | ----------------------------- |
| `Queued`                                       | `Sending`                     |
| `Undelivered`, `Error`                         | `Error`                       |
| `Sent`, `Received`, `Delivered`, `Read`        | `Sent`                        |

> Note: If the medium is not WhatsApp, it falls back to the default `set_delivery_status` implementation.

---

### Testing

- Verified with outbound WhatsApp messages.
- Simulated status updates via Twilio's webhook.
- Confirmed that the correct status is reflected in the linked Communication document.

![image](https://github.com/user-attachments/assets/193a3042-4cf5-45a1-bdfb-b0e69c755379)

![image](https://github.com/user-attachments/assets/5735c425-9b70-4661-a3e0-3646a8ccc692)

Closes [](https://github.com/ParaLogicTech/twilio-integration/issues/4)
