### PR TITLE
[feature] :(#9) implement whatsapp delivery status reconciliation

### DIFF
--- a/twilio_integration/hooks.py
+++ b/twilio_integration/hooks.py
@@ -66,11 +66,9 @@ scheduler_events = {
 	],
 	"hourly_long": [
 		"twilio_integration.twilio_integration.doctype.whatsapp_message.whatsapp_message.flush_incoming_media_queue",
+		"twilio_integration.twilio_integration.doctype.whatsapp_message.whatsapp_message.reconcile_all_message_delivery_status",
 	],
 	"daily": [
 		"twilio_integration.twilio_integration.doctype.whatsapp_message.whatsapp_message.expire_whatsapp_message_queue",
-	],
-	"daily_long": [
-		"twilio_integration.twilio_integration.doctype.whatsapp_message.whatsapp_message.reconcile_all_message_delivery_status",
 	],
 }

--- a/twilio_integration/hooks.py
+++ b/twilio_integration/hooks.py
@@ -70,4 +70,7 @@ scheduler_events = {
 	"daily": [
 		"twilio_integration.twilio_integration.doctype.whatsapp_message.whatsapp_message.expire_whatsapp_message_queue",
 	],
+	"daily_long": [
+		"twilio_integration.twilio_integration.doctype.whatsapp_message.whatsapp_message.reconcile_all_message_delivery_status",
+	],
 }

--- a/twilio_integration/twilio_integration/doctype/whatsapp_message/whatsapp_message.py
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_message/whatsapp_message.py
@@ -370,7 +370,7 @@ class WhatsAppMessage(Document):
 			"sent_received": "Sent",
 		})
 
-	def update_message_delivery_status(cls):
+	def update_message_delivery_status(self):
 		"""
 		This method Reconciles delivery status for a single message with status 'Sent' or 'Queued'
 		"""
@@ -378,19 +378,19 @@ class WhatsAppMessage(Document):
 			frappe.msgprint(_("WhatsApp messages are muted"))
 			return
 
-		if cls.status not in ('Sent', 'Queued'):
+		if self.status not in ('Sent', 'Queued'):
 			return
 
-		original_message_status = cls.status
-		new_message_status = Twilio.get_message(cls.id).status.title()
+		original_message_status = self.status
+		new_message_status = Twilio.get_message(self.id).status.title()
 
 		if not new_message_status or (new_message_status == original_message_status):
 			return
 
-		cls.db_set("status", new_message_status, commit=False)
+		self.db_set("status", new_message_status, commit=False)
 
-		if cls.communication:
-			frappe.get_doc('Communication', cls.communication).set_delivery_status(commit=False)
+		if self.communication:
+			frappe.get_doc('Communication', self.communication).set_delivery_status(commit=False)
 
 def outgoing_message_status_callback(args, auto_commit=False):
 	message = frappe.db.get_value("WhatsApp Message", filters={

--- a/twilio_integration/twilio_integration/doctype/whatsapp_message/whatsapp_message.py
+++ b/twilio_integration/twilio_integration/doctype/whatsapp_message/whatsapp_message.py
@@ -756,7 +756,51 @@ def on_doctype_update():
 	frappe.db.add_index('WhatsApp Message', ('`to`', 'status', 'date_sent'), 'index_indirect_reply')
 
 
-def reconcile_one_message_delivery_status(message_doc,auto_commit=True):
+def reconcile_all_message_delivery_status(limit=100, auto_commit=True):
+	"""
+	Reconcile delivery status for all messages with status 'Sent' or 'Queued'
+	This method processes messages in batches with proper error handling
+	"""
+	if are_whatsapp_messages_muted():
+		frappe.msgprint(_("WhatsApp messages are muted"))
+		return
+
+	messages_to_reconcile = get_pending_reconciliation_messages(limit)
+
+	for msg_data in messages_to_reconcile:
+		try:
+			message_doc = frappe.get_doc("WhatsApp Message", msg_data.name, for_update=True)
+			reconcile_one_message_delivery_status(message_doc)
+
+			if auto_commit:
+				frappe.db.commit()
+
+		except Exception as e:
+			if auto_commit:
+				frappe.db.rollback()
+
+			frappe.log_error(
+				title=_("Error in delivery status reconciliation"),
+				message="Error: {0}".format(str(e)),
+			)
+
+
+def get_pending_reconciliation_messages(limit):
+	"""
+	Fetch WhatsApp messages with status 'Sent' or 'Queued' and that haven't received delivery confirmation
+	"""
+	return frappe.db.sql("""
+		SELECT name, id
+		FROM `tabWhatsApp Message`
+		WHERE status IN ('Sent', 'Queued')
+		AND sent_received = 'Sent'
+		AND id IS NOT NULL
+		ORDER BY creation DESC
+		LIMIT %s
+		""", (limit,), as_dict=True)
+
+
+def reconcile_one_message_delivery_status(message_doc):
 	"""
 	This method Reconciles delivery status for a single message with status 'Sent' or 'Queued'
 	"""
@@ -768,7 +812,7 @@ def reconcile_one_message_delivery_status(message_doc,auto_commit=True):
 		return
 
 	original_message_status = message_doc.status
-	new_message_status = Twilio.get_message_status(message_doc.id)
+	new_message_status = Twilio.get_message(message_doc.id).status.title()
 
 	if not new_message_status or (new_message_status == original_message_status):
 		return
@@ -777,43 +821,3 @@ def reconcile_one_message_delivery_status(message_doc,auto_commit=True):
 
 	if message_doc.communication:
 		frappe.get_doc('Communication', message_doc.communication).set_delivery_status(commit=False)
-
-	if auto_commit:
-		frappe.db.commit()
-
-
-@frappe.whitelist()
-def reconcile_all_message_delivery_status(limit=100, auto_commit=True):
-	"""
-	Reconcile delivery status for all messages with status 'Sent' or 'Queued'
-	This method processes messages in batches with proper error handling
-	"""
-	if are_whatsapp_messages_muted():
-		frappe.msgprint(_("WhatsApp messages are muted"))
-		return
-
-	messages_to_reconcile = frappe.db.sql("""
-		SELECT name, id
-		FROM `tabWhatsApp Message`
-		WHERE status IN ('Sent', 'Queued')
-		AND sent_received = 'Sent'
-		AND id IS NOT NULL
-		ORDER BY creation DESC
-		LIMIT %s
-		""", (limit,), as_dict=True)
-
-	for msg_data in messages_to_reconcile:
-		try:
-			message_doc = frappe.get_doc("WhatsApp Message", msg_data.name, for_update=True)
-			reconcile_one_message_delivery_status(message_doc)
-
-		except Exception as e:
-			if auto_commit:
-				frappe.db.rollback()
-
-			frappe.log_error(
-				title=_("Error in delivery status reconciliation"),
-				message="Message: {0}\nMessage SID: {1}\nError: {2}".format(msg_data.name,msg_data.id,str(e)),
-				reference_doctype="WhatsApp Message",
-				reference_name=msg_data.name
-			)

--- a/twilio_integration/twilio_integration/twilio_handler.py
+++ b/twilio_integration/twilio_integration/twilio_handler.py
@@ -146,6 +146,14 @@ class Twilio:
 
 		return response
 
+	@classmethod
+	def get_message_status(cls, message_id):
+		"""
+		Fetch the current status for this message from Twilio API and returns it
+		"""
+		client = cls.get_twilio_client()
+		message = client.messages(message_id).fetch()
+		return message.status.title()
 
 class IncomingCall:
 	def __init__(self, from_number, to_number, meta=None):

--- a/twilio_integration/twilio_integration/twilio_handler.py
+++ b/twilio_integration/twilio_integration/twilio_handler.py
@@ -147,13 +147,13 @@ class Twilio:
 		return response
 
 	@classmethod
-	def get_message_status(cls, message_id):
+	def get_message(cls, message_id):
 		"""
 		Fetch the current status for this message from Twilio API and returns it
 		"""
 		client = cls.get_twilio_client()
 		message = client.messages(message_id).fetch()
-		return message.status.title()
+		return message
 
 class IncomingCall:
 	def __init__(self, from_number, to_number, meta=None):


### PR DESCRIPTION
## PR Description: Implement WhatsApp Message Delivery Status Reconciliation

This pull request introduces functionality to automatically reconcile the delivery status of sent WhatsApp messages with the Twilio API. This ensures that the status of messages in the Frappe system accurately reflects their actual delivery status as reported by Twilio.

**Key changes implemented:**

* **`reconcile_one_message_delivery_status(message_doc, auto_commit=True)`:**
    * A new method added to the `WhatsAppMessage` doctype.
    * This method takes a single `WhatsApp Message` document as input.
    * It checks if the message status is either "Sent" or "Queued".
    * It calls the `get_message_status` method in the `Twilio` handler to fetch the latest delivery status from the Twilio API for the message's SID.
    * If a new status is retrieved and it's different from the current status, it updates the `status` field of the `WhatsApp Message` document and the delivery status of the associated `Communication` document (if any).
    * Includes an `auto_commit` flag for flexibility in transaction management.

* **`reconcile_all_message_delivery_status(limit=100, auto_commit=True)`:**
    * A new whitelisted method added to the `WhatsAppMessage` doctype.
    * This method fetches a batch of `WhatsApp Message` records with a status of "Sent" or "Queued".
    * It iterates through these messages and calls `reconcile_one_message_delivery_status` for each message within a `try...except` block for robust error handling.
    * On encountering an exception during the reconciliation of a single message, it logs the error with relevant details (message name, SID, and the error itself) and rolls back the database transaction if `auto_commit` is True, ensuring that failures for one message do not prevent the reconciliation of others.
    * The `limit` parameter allows for processing messages in batches to avoid overwhelming resources.

* **`get_message_status(cls, message_id)`:**
    * A new static method added to the `Twilio` handler.
    * This method takes a Twilio Message SID (`message_id`) as input.
    * It uses the Twilio API client to fetch the details of the message.
    * It returns the title-cased status of the message as reported by Twilio (e.g., "Delivered", "Read", "Failed").

* **Scheduler Integration:**
    * The `reconcile_all_message_delivery_status` method has been added to the `daily_long` event in the application's `hooks.py`.
    * This ensures that the delivery status reconciliation process runs automatically once every day during off-peak hours, keeping the message statuses up-to-date without manual intervention.
    
 Closes https://github.com/ParaLogicTech/twilio-integration/issues/9